### PR TITLE
First *stable* iteration of the VM

### DIFF
--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -16,7 +16,7 @@ opt-level = 3
 codegen-units = 1
 
 [dependencies]
-atlas-core = "0.6.0-beta3"
+atlas-core = "0.6.0-beta5"
 internment = "0.8.4"
 
 [dev-dependencies]

--- a/vm/benches/vm_benchmark.rs
+++ b/vm/benches/vm_benchmark.rs
@@ -1,43 +1,45 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use vm::{
-    instruction::{
-        Address,
-        Instruction::{self, *},
-    },
-    runtime::VM,
-};
+use criterion::{criterion_group, criterion_main, Criterion};
+use vm::{instruction::compiler::parser::Parser, runtime::VM};
 
 fn vm_test_benchmark(c: &mut Criterion) {
-    let ins = black_box(vec![
-        PushI(25),
-        Call(Address::Val(4)),
-        Nop,
-        HLT,
-        Dup,
-        PushI(2),
-        Lt,
-        JmpZ(Address::Val(9)),
-        Ret,
-        Dup,
-        PushI(1),
-        SubI,
-        Call(Address::Val(4)),
-        Swap,
-        PushI(2),
-        SubI,
-        Call(Address::Val(4)),
-        AddI,
-        Ret,
-    ]);
-    let mut vm = VM::new();
-    let mut counter = 0;
     c.bench_function("vm_instruction", |b| {
         b.iter(|| {
-            vm.execute_instruction(&ins[0]);
-            vm.stack.top = 1;
-            counter += 1;
-            if counter >= ins.len() {
-                counter = 0
+            //let tmp = std::time::Instant::now();
+            if let Ok(content) = std::fs::read_to_string("./src/example.txt") {
+                let mut lexer = vm::instruction::compiler::lexer::AtlasLexer::default();
+                lexer.set_path("src/example.txt");
+                lexer.set_source(content);
+                lexer.add_system(vm::instruction::compiler::lexer::identifier_system);
+                lexer.add_system(vm::instruction::compiler::lexer::comment_system);
+                let res = lexer.tokenize();
+                match res {
+                    Ok(t) => {
+                        //println!("Ok Lexer: {:?}", tmp.elapsed());
+                        //let tmp = std::time::Instant::now();
+                        //t.clone().into_iter().for_each(|ins| println!("{:?}, ", ins.kind()));
+                        let parser = Parser::parse(t);
+                        match parser {
+                            Ok(code) => {
+                                //println!("Ok Parser: {:?}", tmp.elapsed());
+                                //let tmp = std::time::Instant::now();
+                                //code.clone().into_iter().for_each(|ins| println!("{:?}", ins));
+                                let mut vm = VM::new();
+                                //#[cfg(debug_assertions)]
+                                //vm.set_fn_name(code.fn_name);
+                                vm.execute(code.ins, code.constants);
+                                //println!("Ok Excution: {:?}", tmp.elapsed())
+                            }
+                            Err(e) => {
+                                panic!("{:?}", e);
+                            }
+                        };
+                    }
+                    Err(_e) => {
+                        println!("Error1");
+                    }
+                }
+            } else {
+                println!("Error2")
             }
         })
     });

--- a/vm/benches/vm_benchmark.rs
+++ b/vm/benches/vm_benchmark.rs
@@ -16,7 +16,7 @@ fn vm_test_benchmark(c: &mut Criterion) {
         Dup,
         PushI(2),
         Lt,
-        JumpIfFalse(Address::Val(9)),
+        JmpZ(Address::Val(9)),
         Ret,
         Dup,
         PushI(1),

--- a/vm/examples/brainfuck.txt
+++ b/vm/examples/brainfuck.txt
@@ -121,7 +121,6 @@ main:
             push_i $91
             eq
             jmp_z &default_case
-            pop
             dup         ; duplicate i for future use
             print
             call &l_brace
@@ -198,11 +197,12 @@ dot:
     ret
 
 comma:
-    load_const #state_ptr
     read_i          ; read an i64 from stdin
+    load_const #state_ptr
+    get_struct $0
+    dup
+    get_struct $0
     swap
-    get_struct $0
-    get_struct $0
     set_struct $0
     ret
 

--- a/vm/examples/extern_call.rs
+++ b/vm/examples/extern_call.rs
@@ -5,23 +5,10 @@ use vm::runtime::vm_state::VMState;
 use vm::runtime::VM;
 
 fn main() {
-    // std::env::set_var("RUST_BACKTRACE", "1");
-    /*let mut tmp = Duration::new(0, 0);
-    let mut stack_machine = VM::new();
-    let ins = vec![];
-    for _ in 0..TEST_AMOUNT {
-        use std::time;
-        let ins = ins.clone();
-        let instant = time::Instant::now();
-        stack_machine.execute(ins);
-        tmp += instant.elapsed();
-        stack_machine.clean();
-    }
-    println!("tmp1: {:?}", tmp.div_f32(TEST_AMOUNT as f32));*/
     let tmp = std::time::Instant::now();
-    if let Ok(content) = std::fs::read_to_string("./vm/src/extern_call.txt") {
+    if let Ok(content) = std::fs::read_to_string("./vm/examples/extern_call.txt") {
         let mut lexer = vm::instruction::compiler::lexer::AtlasLexer::default();
-        lexer.set_path("src/extern_call.txt");
+        lexer.set_path("examples/extern_call.txt");
         lexer.set_source(content);
         lexer.add_system(vm::instruction::compiler::lexer::identifier_system);
         lexer.add_system(vm::instruction::compiler::lexer::comment_system);
@@ -30,18 +17,12 @@ fn main() {
             Ok(t) => {
                 println!("Ok Lexer: {:?}", tmp.elapsed());
                 let tmp = std::time::Instant::now();
-                //t.clone().into_iter().for_each(|ins| println!("{:?}, ", ins.kind()));
                 let parser = Parser::parse(t);
                 match parser {
                     Ok(code) => {
                         println!("Ok Parser: {:?}", tmp.elapsed());
                         let tmp = std::time::Instant::now();
-                        //code.clone().into_iter().for_each(|ins| println!("{:?}", ins));
                         let mut vm = VM::new();
-                        #[cfg(debug_assertions)]
-                        println!("{:?}", code.fn_name);
-                        #[cfg(debug_assertions)]
-                        vm.set_fn_name(code.fn_name);
                         vm.add_extern_call(fib_extern)
                         .execute(code.ins, code.constants);
                         println!("Ok Excution: {:?}", tmp.elapsed())

--- a/vm/examples/extern_call.txt
+++ b/vm/examples/extern_call.txt
@@ -1,0 +1,9 @@
+.section
+    @int fib_n 20
+.code
+
+main:
+    load_const #fib_n
+    extern_call $0
+    print
+    hlt

--- a/vm/examples/fib.rs
+++ b/vm/examples/fib.rs
@@ -5,23 +5,10 @@ use vm::runtime::vm_state::VMState;
 use vm::runtime::VM;
 
 fn main() {
-    // std::env::set_var("RUST_BACKTRACE", "1");
-    /*let mut tmp = Duration::new(0, 0);
-    let mut stack_machine = VM::new();
-    let ins = vec![];
-    for _ in 0..TEST_AMOUNT {
-        use std::time;
-        let ins = ins.clone();
-        let instant = time::Instant::now();
-        stack_machine.execute(ins);
-        tmp += instant.elapsed();
-        stack_machine.clean();
-    }
-    println!("tmp1: {:?}", tmp.div_f32(TEST_AMOUNT as f32));*/
     let tmp = std::time::Instant::now();
-    if let Ok(content) = std::fs::read_to_string("./vm/src/extern_call.txt") {
+    if let Ok(content) = std::fs::read_to_string("./vm/examples/fib.txt") {
         let mut lexer = vm::instruction::compiler::lexer::AtlasLexer::default();
-        lexer.set_path("src/extern_call.txt");
+        lexer.set_path("examples/fib.txt");
         lexer.set_source(content);
         lexer.add_system(vm::instruction::compiler::lexer::identifier_system);
         lexer.add_system(vm::instruction::compiler::lexer::comment_system);
@@ -30,18 +17,12 @@ fn main() {
             Ok(t) => {
                 println!("Ok Lexer: {:?}", tmp.elapsed());
                 let tmp = std::time::Instant::now();
-                //t.clone().into_iter().for_each(|ins| println!("{:?}, ", ins.kind()));
                 let parser = Parser::parse(t);
                 match parser {
                     Ok(code) => {
                         println!("Ok Parser: {:?}", tmp.elapsed());
                         let tmp = std::time::Instant::now();
-                        //code.clone().into_iter().for_each(|ins| println!("{:?}", ins));
                         let mut vm = VM::new();
-                        #[cfg(debug_assertions)]
-                        println!("{:?}", code.fn_name);
-                        #[cfg(debug_assertions)]
-                        vm.set_fn_name(code.fn_name);
                         vm.add_extern_call(fib_extern)
                         .execute(code.ins, code.constants);
                         println!("Ok Excution: {:?}", tmp.elapsed())

--- a/vm/examples/fib.txt
+++ b/vm/examples/fib.txt
@@ -1,5 +1,5 @@
 .section
-    @u_int fib_number 1
+    @u_int fib_number 25
 .code
 main:
     load_const #fib_number

--- a/vm/src/brainfuck.txt
+++ b/vm/src/brainfuck.txt
@@ -1,0 +1,331 @@
+.section
+    ; The State is stored at the address 0
+    ; struct State { Cell* ptr; int counter }
+@object state_ptr 0
+    ; The address of the first cell in memory 
+    ; struct Cell { int val }
+@object first 2
+    ; A string is considered an Object too
+@string input 1
+
+.code
+; #[start] drop for now, but it'll come back later
+main: 
+    create_struct $2    ; Initialize the state struct with 2 fields (it's empty for now)
+    
+    load_const #first   ; Adress after the state and the input in memory
+    swap                ; swap over the top 2 so the next instruction has everything in the right order
+    set_struct $0       ; set the 0th field of State to 2 and return the adress (cuz it may change :shrug:)
+    read                ; read the input and put it at the 2nd place in the memory
+    pop                 ; we already know where it is, no need to take more place in the stack
+
+    ; creating 10 cells of memory for the interpreter to work with
+    push_i $0
+    create_struct $1
+    set_struct $0
+    push_i $0
+    create_struct $1
+    set_struct $0
+    push_i $0
+    create_struct $1
+    set_struct $0
+    push_i $0
+    create_struct $1
+    set_struct $0
+    push_i $0
+    create_struct $1
+    set_struct $0
+    push_i $0
+    create_struct $1
+    set_struct $0
+    push_i $0
+    create_struct $1
+    set_struct $0
+    push_i $0
+    create_struct $1
+    set_struct $0
+    push_i $0
+    create_struct $1
+    set_struct $0
+    push_i $0
+    create_struct $1
+    set_struct $0
+
+    ; Now we can really start to implement the interpreter
+
+    push_i $0 ; i
+    main_loop:
+        dup
+        load_const #input
+        str_len
+        lt
+        jmp_z &end
+        dup
+        load_const #input
+        read_char       ; Get the char in the "input_place" string at the i index
+        cast_to_int
+
+        case_l_angle:
+            dup
+            push_i $60        ; 60 is the equivalent of '<' in ASCII
+            eq
+            jmp_z &case_r_angle
+            call &r_angle
+            jmp &i_inc
+        
+        case_r_angle:
+            dup
+            push_i $62
+            eq
+            jmp_z &case_inc
+            call &l_angle
+            jmp &i_inc
+
+        case_inc:
+            dup
+            push_i $43
+            eq
+            jmp_z &case_dec
+            call &inc
+            jmp &i_inc
+
+        case_dec:
+            dup
+            push_i $45
+            eq
+            jmp_z &case_dot
+            call &dec
+            jmp &i_inc
+
+        case_dot:
+            dup
+            push_i $46
+            eq
+            jmp_z &case_comma
+            call &dot
+            jmp &i_inc
+        
+        case_comma:
+            dup
+            push_i $44
+            eq
+            jmp_z &case_l_brace
+            call &comma
+            jmp &i_inc
+        
+        case_l_brace:
+            dup
+            push_i $91
+            eq
+            jmp_z &default_case
+            dup         ; duplicate i for future use
+            call &l_brace
+            jmp &i_inc
+
+        default_case:
+            push_i $123456
+            print
+            hlt
+        
+        i_inc:
+            push_i $1
+            add_i
+            jmp &main_loop
+
+
+    end:
+        hlt
+
+
+r_angle:
+    load_const #state_ptr
+    get_struct $0 ; return the value at the 0th field (state.ptr)
+    push_i $1
+    add_i
+    load_const #state_ptr
+    set_struct $0
+    pop
+    ret
+
+l_angle:
+    load_const #state_ptr
+    get_struct $0
+    push_i $1
+    sub_i
+    load_const #state_ptr
+    set_struct $0
+    pop
+    ret
+
+inc:
+    load_const #state_ptr
+    get_struct $0 ; return the Cell ptr (state.ptr)
+    dup
+    get_struct $0 ; return the value of the cell ptr (cell.val)
+    push_i $1
+    add_i
+    swap
+    set_struct $0 ; inc val (cell.val = cell.val + 1)
+    pop
+    ret
+
+dec:
+    load_const #state_ptr
+    get_struct $0 ; return the Cell ptr (state.ptr)
+    dup
+    get_struct $0 ; return the value of the cell ptr (cell.val)
+    push_i $1
+    sub_i
+    swap
+    set_struct $0 ; dec val (cell.val = cell.val - 1)
+    pop
+    ret
+
+dot:
+    load_const #state_ptr
+    get_struct $0 ; return the Cell ptr (state.ptr)
+    get_struct $0 ; return the value of the cell ptr (cell.val)
+    cast_to_char
+    print_char
+    pop
+    ret
+
+comma:
+    load_const #state_ptr
+    read_i          ; read an i64 from stdin
+    swap
+    get_struct $0
+    get_struct $0
+    set_struct $0
+    ret
+
+
+; The stack should look like if you want the call to work [i, ObjPtr] (if not it doesn't work)
+l_brace:
+    load_const #state_ptr
+    get_struct $0
+    get_struct $0       ; get the value of the current cell
+    jmp_z &l_is_zero
+    pop     ; pop the unused i before returning
+    ret
+
+    l_is_zero:
+        load_const #state_ptr
+        push_i $1
+        swap
+        ; need to keep track of all the '[' before reaching the actual ']'
+        set_struct $1 ; state.counter = state.counter + 1
+
+        l_brace_loop:
+            dup                 ; duplicate i
+            load_const #state_ptr
+            get_struct $1
+            push_i $0
+            eq
+            jmp_nz &l_exit_loop
+            load_const #input
+            read_char
+            dup
+            push_i $91            ; '[' -> 91
+            eq
+            jmp_nz &l_l_brace_found
+            push_i $93            ; ']' -> 93
+            eq
+            jmp_nz &l_r_brace_found
+            jmp &l_inc_i
+
+            l_l_brace_found:
+                pop ; getting rid of the unnecessary duplicated char
+                load_const #state_ptr
+                dup
+                get_struct $2
+                push_i $1
+                add_i
+                swap
+                set_struct $2
+                jmp &l_inc_i
+
+            l_r_brace_found:
+                load_const #state_ptr
+                dup
+                get_struct $2
+                push_i $1
+                sub_i
+                swap
+                set_struct $2
+                jmp &l_inc_i
+
+            l_inc_i:
+                push_i $1
+                add_i
+                jmp &l_brace_loop
+
+            l_exit_loop:
+                pop     ; pop the unused i before returning
+                ret
+
+
+; The stack should look like if you want the call to work [i, ObjPtr] (if not it doesn't work)
+r_brace:
+    load_const #state_ptr
+    get_struct $0
+    get_struct $0       ; get the value of the current cell
+    jmp_nz &r_is_not_zero
+    pop     ; pop the unused i before returning
+    ret
+
+    r_is_not_zero:
+        load_const #state_ptr
+        push_i $1
+        swap
+        ; need to keep track of all the '[' before reaching the actual ']'
+        set_struct $1 ; state.counter = state.counter + 1
+
+        r_brace_loop:
+            dup                 ; duplicate i
+            load_const #state_ptr
+            get_struct $1
+            push_i $0
+            eq
+            jmp_nz &r_exit_loop
+            load_const #input
+            read_char
+            dup
+            push_i $91            ; '[' -> 91
+            eq
+            jmp_nz &r_l_brace_found
+            push_i $93            ; ']' -> 93
+            eq
+            jmp_nz &r_r_brace_found
+            jmp &r_inc_i
+
+            r_l_brace_found:
+                pop ; getting rid of the unnecessary duplicated char
+                load_const #state_ptr
+                dup
+                get_struct $2
+                push_i $1
+                sub_i
+                swap
+                set_struct $2
+                jmp &l_inc_i
+
+            r_r_brace_found:
+                load_const #state_ptr
+                dup
+                get_struct $2
+                push_i $1
+                add_i
+                swap
+                set_struct $2
+                jmp &l_inc_i
+
+            r_inc_i:
+                push_i $1
+                add_i
+                jmp &l_brace_loop
+
+            r_exit_loop:
+                pop     ; pop the unused i before returning
+                ret
+

--- a/vm/src/brainfuck.txt
+++ b/vm/src/brainfuck.txt
@@ -121,7 +121,9 @@ main:
             push_i $91
             eq
             jmp_z &default_case
+            pop
             dup         ; duplicate i for future use
+            print
             call &l_brace
             jmp &i_inc
 
@@ -215,18 +217,19 @@ l_brace:
     ret
 
     l_is_zero:
-        load_const #state_ptr
         push_i $1
-        swap
+        load_const #state_ptr
         ; need to keep track of all the '[' before reaching the actual ']'
         set_struct $1 ; state.counter = state.counter + 1
 
         l_brace_loop:
             dup                 ; duplicate i
+            print
             load_const #state_ptr
             get_struct $1
             push_i $0
             eq
+            cast_to_int
             jmp_nz &l_exit_loop
             load_const #input
             read_char
@@ -243,21 +246,21 @@ l_brace:
                 pop ; getting rid of the unnecessary duplicated char
                 load_const #state_ptr
                 dup
-                get_struct $2
+                get_struct $1
                 push_i $1
                 add_i
                 swap
-                set_struct $2
+                set_struct $1
                 jmp &l_inc_i
 
             l_r_brace_found:
                 load_const #state_ptr
                 dup
-                get_struct $2
+                get_struct $1
                 push_i $1
                 sub_i
                 swap
-                set_struct $2
+                set_struct $1
                 jmp &l_inc_i
 
             l_inc_i:
@@ -292,6 +295,7 @@ r_brace:
             get_struct $1
             push_i $0
             eq
+            cast_to_int
             jmp_nz &r_exit_loop
             load_const #input
             read_char
@@ -308,21 +312,21 @@ r_brace:
                 pop ; getting rid of the unnecessary duplicated char
                 load_const #state_ptr
                 dup
-                get_struct $2
+                get_struct $1
                 push_i $1
                 sub_i
                 swap
-                set_struct $2
+                set_struct $1
                 jmp &l_inc_i
 
             r_r_brace_found:
                 load_const #state_ptr
                 dup
-                get_struct $2
+                get_struct $1
                 push_i $1
                 add_i
                 swap
-                set_struct $2
+                set_struct $1
                 jmp &l_inc_i
 
             r_inc_i:

--- a/vm/src/brainfuck.txt
+++ b/vm/src/brainfuck.txt
@@ -58,7 +58,10 @@ main:
         dup
         load_const #input
         str_len
-        lt
+        push_i $1
+        sub_i
+        lte
+        cast_to_int
         jmp_z &end
         dup
         load_const #input
@@ -132,26 +135,28 @@ main:
             add_i
             jmp &main_loop
 
-
     end:
         hlt
 
-
-r_angle:
+l_angle:
     load_const #state_ptr
     get_struct $0 ; return the value at the 0th field (state.ptr)
+    cast_to_int
     push_i $1
     add_i
+    cast_to_ptr
     load_const #state_ptr
     set_struct $0
     pop
     ret
 
-l_angle:
+r_angle:
     load_const #state_ptr
     get_struct $0
+    cast_to_int
     push_i $1
     sub_i
+    cast_to_ptr
     load_const #state_ptr
     set_struct $0
     pop

--- a/vm/src/example.txt
+++ b/vm/src/example.txt
@@ -1,8 +1,8 @@
 .section
-    @u_int fib_number 40
+    @u_int fib_number 1
 .code
 main:
-    load_const #fib_number ; Should be made into a constant
+    load_const #fib_number
     call &fib
     print
     hlt

--- a/vm/src/example.txt
+++ b/vm/src/example.txt
@@ -1,25 +1,26 @@
 .section
+    @u_int fib_number 40
 .code
-#[start]
 main:
-    push $40
+    load_const #fib_number ; Should be made into a constant
     call &fib
     print
     hlt
 fib:
-    dup
-    push $2
+    dup 
+    push_i $2
     lt
-    jmpz $9
+    jmp_z &next_
     ret
+next_:
     dup
-    push $1
-    sub
+    push_i $1
+    sub_i
     call &fib
 
     swap
-    push $2
-    sub
+    push_i $2
+    sub_i
     call &fib
-    add
+    add_i
     ret

--- a/vm/src/instruction/compiler/lexer/mod.rs
+++ b/vm/src/instruction/compiler/lexer/mod.rs
@@ -7,15 +7,98 @@ symbols!(
     '#' => HashTag,
     '.' => Dot,
     ':' => Colon,
-    ';' => SemiColon,
     '&' => Ampersand,
     '[' => LBracket,
-    ']' => RBracket
+    ']' => RBracket,
+    '@' => AtSign
 );
 keywords!(
-    "section", "code", "start", "push", "call", "print", "hlt", "dup", "lt", "lte", "gt", "gte",
-    "jmp", "jmpz", "jmpnz", "ret", "swap", "add", "sub", "mul", "div"
+    "section",
+    "start",
+    "code",
+    "push_i",
+    "push_u",
+    "push_f",
+    "load_const",
+    "pop",
+    "add_i",
+    "add_u",
+    "add_f",
+    "sub_i",
+    "sub_u",
+    "sub_f",
+    "mul_i",
+    "mul_u",
+    "mul_f",
+    "div_i",
+    "div_u",
+    "div_f",
+    "dup",
+    "swap",
+    "rot",
+    "jmp_nz",
+    "jmp_z",
+    "jmp",
+    "call",
+    "ret",
+    "print_char",
+    "print",
+    "read",
+    "read_i",
+    "set_struct",
+    "get_struct",
+    "create_struct",
+    "create_string",
+    "str_len",
+    "write_char",
+    "read_char",
+    "eq",
+    "neq",
+    "lt",
+    "gt",
+    "lte",
+    "gte",
+    "and",
+    "or",
+    "not",
+    "hlt",
+    "nop",
+    "cast_to_int",
+    "cast_to_uint",
+    "cast_to_float",
+    "cast_to_char",
+    "cast_to_bool",
+    "int",
+    "u_int",
+    "float",
+    "char",
+    "object",
+    "string",
+    "bool"
 );
+
+pub fn comment_system(c: char, state: &mut LexerState) -> Option<Token> {
+    if c == ';' {
+        let start = state.current_pos;
+        state.next();
+        while let Some(c) = state.peek() {
+            if *c == '\n' {
+                break;
+            }
+            state.next();
+        }
+        return Some(Token {
+            span: Span {
+                start,
+                end: state.current_pos,
+                path: state.path,
+            },
+            kind: TokenKind::WhiteSpace,
+        });
+    }
+
+    None
+}
 
 pub fn identifier_system(c: char, state: &mut LexerState) -> Option<Token> {
     if c.is_alphabetic() || c == '_' {

--- a/vm/src/instruction/compiler/lexer/mod.rs
+++ b/vm/src/instruction/compiler/lexer/mod.rs
@@ -39,6 +39,7 @@ keywords!(
     "jmp_nz",
     "jmp_z",
     "jmp",
+    "extern_call",
     "call",
     "ret",
     "print_char",

--- a/vm/src/instruction/compiler/lexer/mod.rs
+++ b/vm/src/instruction/compiler/lexer/mod.rs
@@ -68,6 +68,7 @@ keywords!(
     "cast_to_float",
     "cast_to_char",
     "cast_to_bool",
+    "cast_to_ptr",
     "int",
     "u_int",
     "float",

--- a/vm/src/instruction/compiler/mod.rs
+++ b/vm/src/instruction/compiler/mod.rs
@@ -1,2 +1,2 @@
-pub(crate) mod lexer;
-pub(crate) mod parser;
+pub mod lexer;
+pub mod parser;

--- a/vm/src/instruction/compiler/parser/mod.rs
+++ b/vm/src/instruction/compiler/parser/mod.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashMap, iter::Peekable, vec::IntoIter};
+use std::{iter::Peekable, vec::IntoIter};
 
 use crate::instruction::compiler::lexer::{Literal, Token, TokenKind};
 use crate::instruction::{Address, Instruction};
-use crate::memory::object_map::{Object, ObjectIndex};
+use crate::memory::object_map::ObjectIndex;
 use crate::memory::vm_data::VMData;
 use atlas_core::prelude::Spanned;
 use internment::Intern;
@@ -78,7 +78,7 @@ impl Parser {
                     })
                 }
                 Err(_e) => {
-                    return Err(());
+                    Err(())
                 }
             }
         } else {
@@ -125,7 +125,7 @@ impl Parser {
                                 "string" => Type::String,
                                 _ => unreachable!("This isn't good bro"),
                             },
-                            k => {
+                            _ => {
                                 unreachable!("This isn't good bro")
                             }
                         };
@@ -210,7 +210,7 @@ impl Parser {
                     match i {
                         Instruction::Call(a) => {
                             let mut position = 0;
-                            (&blocks).into_iter().for_each(|b| {
+                            blocks.iter().for_each(|b| {
                                 if b.id
                                     == match a {
                                         Address::ToDefine(i) => *i,
@@ -225,7 +225,7 @@ impl Parser {
                         }
                         Instruction::Jmp(a) => {
                             let mut position = 0;
-                            (&blocks).into_iter().for_each(|b| {
+                            blocks.iter().for_each(|b| {
                                 if b.id
                                     == match a {
                                         Address::ToDefine(i) => *i,
@@ -240,7 +240,7 @@ impl Parser {
                         }
                         Instruction::JmpNZ(a) => {
                             let mut position = 0;
-                            (&blocks).into_iter().for_each(|b| {
+                            blocks.iter().for_each(|b| {
                                 if b.id
                                     == match a {
                                         Address::ToDefine(i) => *i,
@@ -255,7 +255,7 @@ impl Parser {
                         }
                         Instruction::JmpZ(a) => {
                             let mut position = 0;
-                            (&blocks).into_iter().for_each(|b| {
+                            blocks.iter().for_each(|b| {
                                 if b.id
                                     == match a {
                                         Address::ToDefine(i) => *i,
@@ -396,7 +396,6 @@ impl Parser {
                                                     .for_each(|(u, c)| {
                                                         if c.id == i {
                                                             position = u;
-                                                            return;
                                                         }
                                                     });
                                                 block.ins.push(Instruction::LoadConst(position))
@@ -759,6 +758,6 @@ impl Parser {
                 //consume the token
             }
         }
-        return Ok(block);
+        Ok(block)
     }
 }

--- a/vm/src/instruction/compiler/parser/mod.rs
+++ b/vm/src/instruction/compiler/parser/mod.rs
@@ -1,48 +1,86 @@
 use std::{collections::HashMap, iter::Peekable, vec::IntoIter};
 
-use crate::instruction::compiler::lexer::{AtlasLexer, Token, TokenKind};
-use crate::instruction::Instruction;
+use crate::instruction::compiler::lexer::{Literal, Token, TokenKind};
+use crate::instruction::{Address, Instruction};
+use crate::memory::object_map::{Object, ObjectIndex};
+use crate::memory::vm_data::VMData;
+use atlas_core::prelude::Spanned;
 use internment::Intern;
 
+#[derive(Debug, Clone, Copy)]
+pub enum Type {
+    Object,
+    String,
+    I64,
+    F64,
+    U64,
+    Char,
+    Bool,
+}
+
+#[derive(Debug)]
 pub struct Block {
-    id: Intern<String>,
-    ins: Vec<Instruction>,
-    len: usize,
+    pub id: Intern<String>,
+    pub ins: Vec<Instruction>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Constant {
+    pub id: Intern<String>,
+    pub value: VMData
 }
 
 pub struct Program {
     pub ins: Vec<Instruction>,
-    pub constants: HashMap<Intern<String>, i32>,
+    pub constants: Vec<VMData>,
+    pub fn_name: Vec<(String, usize)>,
 }
 
 pub struct Parser {
     tokens: Peekable<IntoIter<Token>>,
     blocks: Vec<Block>,
-    constants: HashMap<Intern<String>, i32>,
+    constants: Vec<Constant>,
     pos: usize,
 }
 
 impl Parser {
-    pub fn parse(tokens: Vec<Token>) -> Result<Vec<Instruction>, ()> {
+    pub fn parse(tokens: Vec<Token>) -> Result<Program, ()> {
         let toks = tokens.into_iter().peekable();
         let mut parser = Parser {
             tokens: toks,
             blocks: Vec::new(),
-            constants: HashMap::new(),
+            constants: vec![],
             pos: 0,
         };
-        match parser.parse_section() {
-            Ok(_) => match parser.parse_code() {
-                Ok(_) => {}
-                Err(e) => {
+        if let TokenKind::SoI = parser.tokens.next().unwrap().kind() {
+            match parser.parse_section() {
+                Ok(constants) => {
+                    parser.constants = constants;
+                    let ins = parser.parse_code()?;
+                    let mut consts = vec![];
+                    parser.constants.into_iter().for_each(|c| consts.push(c.value));
+                    Ok(Program {
+                        ins,
+                        constants: consts,
+                        fn_name: {
+                            let mut names = vec![];
+                            parser.blocks.into_iter().for_each(|b| {
+                                names.push((b.id.as_str().to_owned(), b.ins.len()));
+                            });
+                            for i in 1..names.len() {
+                                names[i].1 += names[i-1].1
+                            }
+                            names
+                        }
+                    })
+                }
+                Err(_e) => {
                     return Err(());
                 }
-            },
-            Err(e) => {
-                return Err(());
             }
+        } else {
+            Err(())
         }
-        todo!()
     }
     fn is(tok: Option<Token>, t: TokenKind) -> bool {
         if let Some(tok) = tok {
@@ -54,37 +92,685 @@ impl Parser {
 }
 
 impl Parser {
-    fn parse_section(&mut self) -> Result<(), ()> {
+    fn parse_section(&mut self) -> Result<Vec<Constant>, ()> {
         if Parser::is(self.tokens.next(), TokenKind::Dot)
             && Parser::is(
                 self.tokens.next(),
                 TokenKind::Keyword(Intern::new(String::from("section"))),
             )
         {
-            while let Some(tok) = self.tokens.peek() {
-                if tok.kind() == TokenKind::Dot {
+            let mut constants: Vec<Constant> = vec![];
+            loop {
+                if self.tokens.peek().is_none() {
                     break;
                 }
-                match self.parse_const() {
-                    Ok((k, v)) => {
-                        self.constants.insert(Intern::new(k), v);
+                let k = self.tokens.peek().unwrap().kind();
+                match k {
+                    TokenKind::AtSign => {
+                        self.tokens.next();
+                        if self.tokens.peek().is_none() {
+                            panic!("There should be a constant definition after an \"@\"")
+                        }
+                        let t = match self.tokens.next().unwrap().kind() {
+                            TokenKind::Keyword(k) => {
+                                println!("{}", k.as_str());
+                                match k.as_str() {
+                                    "int" => Type::I64,
+                                    "float" => Type::F64,
+                                    "u_int" => Type::U64,
+                                    "char" => Type::Char,
+                                    "bool" => Type::Bool,
+                                    "object" => Type::Object,
+                                    "string" => Type::String,
+                                    _ => unreachable!("This isn't good bro")
+                                }
+                            }
+                            k => {
+                                println!("k: {:?}", k);
+                                unreachable!("This isn't good bro")
+                            }
+                        };
+                        let name = match self.tokens.next().unwrap().kind() {
+                            TokenKind::Literal(Literal::Identifier(i)) => {
+                                i
+                            }
+                            _ => unreachable!("need a name"),
+                        };
+                        let value = match self.tokens.next().unwrap().kind() {
+                            TokenKind::Literal(l) => {
+                                match (t, l) {
+                                    (Type::I64, Literal::Float(f)) => {
+                                        VMData::new_i64(f as i64)
+                                    }
+                                    (Type::U64, Literal::Float(f)) => {
+                                        VMData::new_u64(f as u64)
+                                    }
+                                    (Type::F64, Literal::Float(f)) => {
+                                        VMData::new_f64(f)
+                                    }
+                                    (Type::Object, Literal::Float(f)) => {
+                                        VMData::new_object(257, ObjectIndex::new(f as u64))
+                                    }
+                                    (Type::String, Literal::Float(f)) => {
+                                        println!("Value of {} = {}", name, f);
+                                        VMData::new_string(ObjectIndex::new(f as u64))
+                                    }
+                                    _ => {
+                                        println!("({:?}, {:?})", t, l);
+                                        unreachable!("need a correct value based on the type")
+                                    }
+                                }
+                            }
+                            _ => unreachable!("Need to reach it")
+                        };
+                        constants.push(Constant {
+                            id: name,
+                            value
+                        })
                     }
-                    Err(e) => return Err(e),
+                    _ => return Ok(constants)
                 }
             }
+            Ok(constants)
+        } else {
+            Err(())
         }
-        Ok(())
     }
-    fn parse_const(&mut self) -> Result<(String, i32), ()> {
+    //Return (constant_name, constant_value)
+    fn parse_const(&mut self) -> Result<(Intern<String>, VMData), ()> {
         todo!()
     }
 }
 
 impl Parser {
-    fn parse_code(&mut self) -> Result<(), ()> {
-        todo!()
+    fn parse_code(&mut self) -> Result<Vec<Instruction>, ()> {
+        let mut blocks: Vec<Block> = vec![];
+        if Parser::is(self.tokens.next(), TokenKind::Dot)
+            && Parser::is(
+                self.tokens.next(),
+                TokenKind::Keyword(Intern::new(String::from("code"))),
+            )
+        {
+            loop {
+                if self.tokens.peek().is_none() {
+                    break;
+                }
+                let k = self.tokens.next().unwrap().kind();
+                match k {
+                    TokenKind::Literal(Literal::Identifier(i)) => {
+                        if self.tokens.peek().is_none() {
+                            panic!("There should be a \":\" after {}", i);
+                        }
+                        match self.tokens.next().unwrap().kind() {
+                            TokenKind::Colon => {
+                                let res = self.parse_block(i)?;
+                                blocks.push(res);
+                            }
+                            _ => {
+                                panic!("There should be a colon");
+                            }
+                        }
+                    }
+                    TokenKind::EoI => {
+                        break;
+                    }
+                    _ => {
+                        unreachable!("{:?}", k)
+                    }
+                }
+            }
+            let mut ins: Vec<Instruction> = vec![];
+            for b in &blocks {
+                for i in &b.ins {
+                    match i {
+                        Instruction::Call(a) => {
+                            let mut position = 0;
+                            (&blocks).into_iter().for_each(|b| {
+                                if b.id
+                                    == match a {
+                                        Address::ToDefine(i) => *i,
+                                        Address::Val(_v) => panic!("blabla"),
+                                    }
+                                {
+                                    ins.push(Instruction::Call(Address::Val(position)));
+                                    return;
+                                }
+                                position += b.ins.len();
+                            })
+                        }
+                        Instruction::Jmp(a) => {
+                            let mut position = 0;
+                            (&blocks).into_iter().for_each(|b| {
+                                if b.id
+                                    == match a {
+                                        Address::ToDefine(i) => *i,
+                                        Address::Val(_v) => panic!("blabla"),
+                                    }
+                                {
+                                    ins.push(Instruction::Jmp(Address::Val(position)));
+                                    return;
+                                }
+                                position += b.ins.len();
+                            })
+                        }
+                        Instruction::JmpNZ(a) => {
+                            let mut position = 0;
+                            (&blocks).into_iter().for_each(|b| {
+                                if b.id
+                                    == match a {
+                                        Address::ToDefine(i) => *i,
+                                        Address::Val(_v) => panic!("blabla"),
+                                    }
+                                {
+                                    ins.push(Instruction::JmpNZ(Address::Val(position)));
+                                    return;
+                                }
+                                position += b.ins.len();
+                            })
+                        }
+                        Instruction::JmpZ(a) => {
+                            let mut position = 0;
+                            (&blocks).into_iter().for_each(|b| {
+                                if b.id
+                                    == match a {
+                                        Address::ToDefine(i) => *i,
+                                        Address::Val(_v) => panic!("blabla"),
+                                    }
+                                {
+                                    ins.push(Instruction::JmpZ(Address::Val(position)));
+                                    return;
+                                }
+                                position += b.ins.len();
+                            })
+                        }
+                        _ => {
+                            ins.push(*i);
+                        }
+                    }
+                }
+            }
+            Ok(ins)
+        } else {
+            Err(())
+        }
     }
-    fn parse_block(&mut self) -> Result<Block, ()> {
-        todo!()
+    fn parse_block(&mut self, tag: Intern<String>) -> Result<Block, ()> {
+        let mut block = Block {
+            id: tag,
+            ins: vec![],
+        };
+        loop {
+            if let Some(t) = self.tokens.peek() {
+                let start = t.start();
+                let end = t.end();
+                let k = self.tokens.peek().unwrap().kind();
+                match k {
+                    TokenKind::Keyword(k) => {
+                        self.tokens.next();
+                        match k.as_str() {
+                            "push_i" => {
+                                if let Some(t) = self.tokens.next() {
+                                    let start = t.start();
+                                    let end = t.end();
+                                    if t.kind() == TokenKind::DollarSign {
+                                        if let Some(t) = self.tokens.next() {
+                                            if let TokenKind::Literal(Literal::Float(f)) = t.kind()
+                                            {
+                                                block.ins.push(Instruction::PushI(f as i64))
+                                            }
+                                        } else {
+                                            panic!(
+                                            "There should be something after \"push_i &\" [{}:{}]",
+                                            start, end
+                                        )
+                                        }
+                                    } else {
+                                        panic!(
+                                        "There should be an ampersand (&) after \"push_i\" [{}:{}]",
+                                        start, end
+                                    )
+                                    }
+                                } else {
+                                    panic!(
+                                        "There should be something after \"push_i\" [{}:{}]",
+                                        start, end
+                                    )
+                                }
+                            }
+                            "push_f" => {
+                                if let Some(t) = self.tokens.next() {
+                                    let start = t.start();
+                                    let end = t.end();
+                                    if t.kind() == TokenKind::DollarSign {
+                                        if let Some(t) = self.tokens.next() {
+                                            if let TokenKind::Literal(Literal::Float(i)) = t.kind()
+                                            {
+                                                block.ins.push(Instruction::PushF(i))
+                                            }
+                                        } else {
+                                            panic!(
+                                            "There should be something after \"push_f &\" [{}:{}]",
+                                            start, end
+                                        )
+                                        }
+                                    } else {
+                                        panic!(
+                                        "There should be an ampersand (&) after \"push_f\" [{}:{}]",
+                                        start, end
+                                    )
+                                    }
+                                } else {
+                                    panic!(
+                                        "There should be something after \"push_f\" [{}:{}]",
+                                        start, end
+                                    )
+                                }
+                            }
+                            "push_u" => {
+                                if let Some(t) = self.tokens.next() {
+                                    let start = t.start();
+                                    let end = t.end();
+                                    if t.kind() == TokenKind::DollarSign {
+                                        if let Some(t) = self.tokens.next() {
+                                            if let TokenKind::Literal(Literal::Int(i)) = t.kind() {
+                                                block.ins.push(Instruction::PushU(i as u64))
+                                            }
+                                        } else {
+                                            panic!(
+                                            "There should be something after \"push_u &\" [{}:{}]",
+                                            start, end
+                                        )
+                                        }
+                                    } else {
+                                        panic!(
+                                        "There should be an ampersand (&) after \"push_u\" [{}:{}]",
+                                        start, end
+                                    )
+                                    }
+                                } else {
+                                    panic!(
+                                        "There should be something after \"push_u\" [{}:{}]",
+                                        start, end
+                                    )
+                                }
+                            }
+                            "load_const" => {
+                                if let Some(t) = self.tokens.next() {
+                                    let start = t.start();
+                                    let end = t.end();
+                                    if t.kind() == TokenKind::HashTag {
+                                        if let Some(t) = self.tokens.next() {
+                                            if let TokenKind::Literal(Literal::Identifier(i)) =
+                                                t.kind()
+                                            {
+                                                let mut position = 0;
+                                                self.constants.clone().into_iter().enumerate().for_each(|(u, c)| {
+                                                    if c.id == i {
+                                                        position = u;
+                                                        return
+                                                    }
+                                                });
+                                                block.ins.push(Instruction::LoadConst(
+                                                    position
+                                                ))
+                                            }
+                                        } else {
+                                            panic!(
+                                        "There should be something after \"load_const #\" [{}:{}]",
+                                        start, end
+                                    )
+                                        }
+                                    } else {
+                                        panic!(
+                                    "There should be an hashtag (#) after \"load_const\" [{}:{}]",
+                                    start, end
+                                )
+                                    }
+                                } else {
+                                    panic!(
+                                        "There should be something after \"load_const\" [{}:{}]",
+                                        start, end
+                                    )
+                                }
+                            }
+                            "pop" => block.ins.push(Instruction::Pop),
+                            "add_i" => block.ins.push(Instruction::AddI),
+                            "add_u" => block.ins.push(Instruction::AddU),
+                            "add_f" => block.ins.push(Instruction::AddF),
+                            "sub_i" => block.ins.push(Instruction::SubI),
+                            "sub_u" => block.ins.push(Instruction::SubU),
+                            "sub_f" => block.ins.push(Instruction::SubF),
+                            "mul_i" => block.ins.push(Instruction::MulI),
+                            "mul_u" => block.ins.push(Instruction::MulU),
+                            "mul_f" => block.ins.push(Instruction::MulF),
+                            "div_i" => block.ins.push(Instruction::DivI),
+                            "div_u" => block.ins.push(Instruction::DivU),
+                            "div_f" => block.ins.push(Instruction::DivF),
+                            "dup" => block.ins.push(Instruction::Dup),
+                            "swap" => block.ins.push(Instruction::Swap),
+                            "rot" => block.ins.push(Instruction::Rot),
+                            "jmp" => {
+                                if let Some(t) = self.tokens.next() {
+                                    let start = t.start();
+                                    let end = t.end();
+                                    if t.kind() == TokenKind::Ampersand {
+                                        if let Some(t) = self.tokens.next() {
+                                            let start = t.start();
+                                            let end = t.end();
+                                            if let TokenKind::Literal(l) = t.kind() {
+                                                match l {
+                                                    Literal::Identifier(i) => {
+                                                        block.ins.push(Instruction::Jmp(
+                                                            crate::instruction::Address::ToDefine(
+                                                                i,
+                                                            ),
+                                                        ))
+                                                    }
+                                                    _ => {
+                                                        panic!("There should be a float value after \"load_const #\" [{}:{}]", start, end)
+                                                    }
+                                                }
+                                            } else {
+                                                panic!("There should be a literal value after \"load_const #\" [{}:{}]", start, end)
+                                            }
+                                        } else {
+                                            panic!(
+                                    "There should be something after \"load_const #\" [{}:{}]",
+                                    start, end
+                                )
+                                        }
+                                    } else {
+                                        panic!(
+                                "There should be an hashtag (#) after \"load_const\" [{}:{}]",
+                                start, end
+                            )
+                                    }
+                                } else {
+                                    panic!(
+                                        "There should be something after \"load_const\" [{}:{}]",
+                                        start, end
+                                    )
+                                }
+                            }
+                            "jmp_nz" => {
+                                if let Some(t) = self.tokens.next() {
+                                    let start = t.start();
+                                    let end = t.end();
+                                    if t.kind() == TokenKind::Ampersand {
+                                        if let Some(t) = self.tokens.next() {
+                                            let start = t.start();
+                                            let end = t.end();
+                                            if let TokenKind::Literal(l) = t.kind() {
+                                                match l {
+                                                    Literal::Identifier(i) => {
+                                                        block.ins.push(Instruction::JmpNZ(
+                                                            crate::instruction::Address::ToDefine(
+                                                                i,
+                                                            ),
+                                                        ))
+                                                    }
+                                                    _ => {
+                                                        panic!("There should be a float value after \"load_const #\" [{}:{}]", start, end)
+                                                    }
+                                                }
+                                            } else {
+                                                panic!("There should be a literal value after \"load_const #\" [{}:{}]", start, end)
+                                            }
+                                        } else {
+                                            panic!(
+                                    "There should be something after \"load_const #\" [{}:{}]",
+                                    start, end
+                                )
+                                        }
+                                    } else {
+                                        panic!(
+                                "There should be an hashtag (#) after \"load_const\" [{}:{}]",
+                                start, end
+                            )
+                                    }
+                                } else {
+                                    panic!(
+                                        "There should be something after \"load_const\" [{}:{}]",
+                                        start, end
+                                    )
+                                }
+                            }
+                            "jmp_z" => {
+                                if let Some(t) = self.tokens.next() {
+                                    let start = t.start();
+                                    let end = t.end();
+                                    if t.kind() == TokenKind::Ampersand {
+                                        if let Some(t) = self.tokens.next() {
+                                            let start = t.start();
+                                            let end = t.end();
+                                            if let TokenKind::Literal(l) = t.kind() {
+                                                match l {
+                                                    Literal::Identifier(i) => {
+                                                        block.ins.push(Instruction::JmpZ(
+                                                            crate::instruction::Address::ToDefine(
+                                                                i,
+                                                            ),
+                                                        ))
+                                                    }
+                                                    _ => {
+                                                        panic!("There should be a float value after \"jmp_z &\" [{}:{}]", start, end)
+                                                    }
+                                                }
+                                            } else {
+                                                panic!("There should be a literal value after \"jmp_z &\" [{}:{}]", start, end)
+                                            }
+                                        } else {
+                                            panic!(
+                                    "There should be something after \"jmp_z &\" [{}:{}]",
+                                    start, end
+                                )
+                                        }
+                                    } else {
+                                        panic!(
+                                "There should be an hashtag (#) after \"load_const\" [{}:{}]",
+                                start, end
+                            )
+                                    }
+                                } else {
+                                    panic!(
+                                        "There should be something after \"load_const\" [{}:{}]",
+                                        start, end
+                                    )
+                                }
+                            }
+                            "call" => {
+                                if let Some(t) = self.tokens.next() {
+                                    let start = t.start();
+                                    let end = t.end();
+                                    if t.kind() == TokenKind::Ampersand {
+                                        if let Some(t) = self.tokens.next() {
+                                            let start = t.start();
+                                            let end = t.end();
+                                            if let TokenKind::Literal(l) = t.kind() {
+                                                match l {
+                                                    Literal::Identifier(i) => {
+                                                        block.ins.push(Instruction::Call(
+                                                            crate::instruction::Address::ToDefine(
+                                                                i,
+                                                            ),
+                                                        ))
+                                                    }
+                                                    _ => {
+                                                        panic!("There should be a float value after \"load_const #\" [{}:{}]", start, end)
+                                                    }
+                                                }
+                                            } else {
+                                                panic!("There should be a literal value after \"load_const #\" [{}:{}]", start, end)
+                                            }
+                                        } else {
+                                            panic!(
+                                    "There should be something after \"load_const #\" [{}:{}]",
+                                    start, end
+                                )
+                                        }
+                                    } else {
+                                        panic!(
+                                "There should be an hashtag (#) after \"load_const\" [{}:{}]",
+                                start, end
+                            )
+                                    }
+                                } else {
+                                    panic!(
+                                        "There should be something after \"load_const\" [{}:{}]",
+                                        start, end
+                                    )
+                                }
+                            }
+                            "ret" => block.ins.push(Instruction::Ret),
+                            "print" => block.ins.push(Instruction::Print),
+                            "print_char" => block.ins.push(Instruction::PrintChar),
+                            "read" => block.ins.push(Instruction::Read),
+                            "read_i" => block.ins.push(Instruction::ReadI),
+                            "cast_to_int" => block.ins.push(Instruction::CastToI),
+                            "cast_to_uint" => block.ins.push(Instruction::CastToU),
+                            "cast_to_float" => block.ins.push(Instruction::CastToF),
+                            "cast_to_char" => block.ins.push(Instruction::CastToChar),
+                            "cast_to_bool" => block.ins.push(Instruction::CastToBool),
+                            "set_struct" => {
+                                if let Some(t) = self.tokens.next() {
+                                    let start = t.start();
+                                    let end = t.end();
+                                    if t.kind() == TokenKind::DollarSign {
+                                        if let Some(t) = self.tokens.next() {
+                                            let start = t.start();
+                                            let end = t.end();
+                                            if let TokenKind::Literal(l) = t.kind() {
+                                                match l {
+                                                    Literal::Float(i) => block
+                                                        .ins
+                                                        .push(Instruction::SetStruct(i as usize)),
+                                                    _ => {
+                                                        panic!("There should be an int value after \"push_i &\" [{}:{}]", start, end)
+                                                    }
+                                                }
+                                            } else {
+                                                panic!("There should be a literal value after \"push_i &\" [{}:{}]", start, end)
+                                            }
+                                        } else {
+                                            panic!(
+                                            "There should be something after \"push_i &\" [{}:{}]",
+                                            start, end
+                                        )
+                                        }
+                                    } else {
+                                        panic!(
+                                        "There should be an ampersand (&) after \"push_i\" [{}:{}]",
+                                        start, end
+                                    )
+                                    }
+                                } else {
+                                    panic!(
+                                        "There should be something after \"push_i\" [{}:{}]",
+                                        start, end
+                                    )
+                                }
+                            }
+                            "get_struct" => {
+                                if let Some(t) = self.tokens.next() {
+                                    let start = t.start();
+                                    let end = t.end();
+                                    if t.kind() == TokenKind::DollarSign {
+                                        if let Some(t) = self.tokens.next() {
+                                            let start = t.start();
+                                            let end = t.end();
+                                            if let TokenKind::Literal(l) = t.kind() {
+                                                match l {
+                                                    Literal::Float(i) => block
+                                                        .ins
+                                                        .push(Instruction::GetStruct(i as usize)),
+                                                    _ => {
+                                                        panic!("There should be an int value after \"push_i &\" [{}:{}]", start, end)
+                                                    }
+                                                }
+                                            } else {
+                                                panic!("There should be a literal value after \"push_i &\" [{}:{}]", start, end)
+                                            }
+                                        } else {
+                                            panic!(
+                                            "There should be something after \"push_i &\" [{}:{}]",
+                                            start, end
+                                        )
+                                        }
+                                    } else {
+                                        panic!(
+                                        "There should be an ampersand (&) after \"push_i\" [{}:{}]",
+                                        start, end
+                                    )
+                                    }
+                                } else {
+                                    panic!(
+                                        "There should be something after \"push_i\" [{}:{}]",
+                                        start, end
+                                    )
+                                }
+                            }
+                            "create_struct" => {
+                                if let Some(t) = self.tokens.next() {
+                                    let start = t.start();
+                                    let end = t.end();
+                                    if t.kind() == TokenKind::DollarSign {
+                                        if let Some(t) = self.tokens.next() {
+                                            let start = t.start();
+                                            let end = t.end();
+                                            if let TokenKind::Literal(l) = t.kind() {
+                                                match l {
+                                                    Literal::Float(i) => block.ins.push(
+                                                        Instruction::CreateStruct(i as usize),
+                                                    ),
+                                                    _ => {
+                                                        panic!("There should be an int value after \"push_i &\" [{}:{}] ({:?})", start, end, t.kind())
+                                                    }
+                                                }
+                                            } else {
+                                                panic!("There should be a literal value after \"push_i &\" [{}:{}]", start, end)
+                                            }
+                                        } else {
+                                            panic!(
+                                            "There should be something after \"push_i &\" [{}:{}]",
+                                            start, end
+                                        )
+                                        }
+                                    } else {
+                                        panic!(
+                                        "There should be an ampersand (&) after \"push_i\" [{}:{}]",
+                                        start, end
+                                    )
+                                    }
+                                } else {
+                                    panic!(
+                                        "There should be something after \"push_i\" [{}:{}]",
+                                        start, end
+                                    )
+                                }
+                            }
+                            "create_string" => block.ins.push(Instruction::CreateString),
+                            "str_len" => block.ins.push(Instruction::StrLen),
+                            "write_char" => block.ins.push(Instruction::WriteCharToString),
+                            "read_char" => block.ins.push(Instruction::ReadCharFromString),
+                            "eq" => block.ins.push(Instruction::Eq),
+                            "neq" => block.ins.push(Instruction::Neq),
+                            "lt" => block.ins.push(Instruction::Lt),
+                            "gt" => block.ins.push(Instruction::Gt),
+                            "lte" => block.ins.push(Instruction::Lte),
+                            "gte" => block.ins.push(Instruction::Gte),
+                            "and" => block.ins.push(Instruction::And),
+                            "or" => block.ins.push(Instruction::Or),
+                            "not" => block.ins.push(Instruction::Not),
+                            "hlt" => block.ins.push(Instruction::HLT),
+                            "nop" => block.ins.push(Instruction::Nop),
+                            _ => break,
+                        }
+                    }
+                    _ => return Ok(block),
+                }
+                //consume the token
+            }
+        }
+        return Ok(block);
     }
 }

--- a/vm/src/instruction/compiler/parser/mod.rs
+++ b/vm/src/instruction/compiler/parser/mod.rs
@@ -564,6 +564,19 @@ impl Parser {
                                     )
                                 }
                             }
+                            "extern_call" => {
+                                if let Some(t) = self.tokens.next() {
+                                    if t.kind() == TokenKind::DollarSign {
+                                        if let Some(t) = self.tokens.next() {
+                                            if let TokenKind::Literal(Literal::Float(f)) = t.kind() {
+                                                block.ins.push(Instruction::ExternCall(f as usize))
+                                            } else {
+                                                panic!("there should be a number here")
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                             "call" => {
                                 if let Some(t) = self.tokens.next() {
                                     let start = t.start();

--- a/vm/src/instruction/mod.rs
+++ b/vm/src/instruction/mod.rs
@@ -1,4 +1,6 @@
-pub(crate) mod compiler;
+use internment::Intern;
+
+pub mod compiler;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Instruction {
@@ -29,13 +31,24 @@ pub enum Instruction {
     Rot,
 
     Jmp(Address),
-    JumpIfTrue(Address),
-    JumpIfFalse(Address),
-    Call(Address),
+    JmpNZ(Address),
+    JmpZ(Address),
+    Call(Address), //Should it uses the top of the stack value as adress if the Address is `ToDefine`? Or maybe adding another way?
     Ret,
 
     Print,
+    PrintChar,
     Read,
+    ReadI,
+
+    SetStruct(usize),
+    GetStruct(usize),
+    CreateStruct(usize),
+
+    CreateString,
+    StrLen,
+    WriteCharToString,
+    ReadCharFromString,
 
     Eq,
     Neq,
@@ -47,15 +60,20 @@ pub enum Instruction {
     Or,
     Not,
 
+    CastToI,
+    CastToF,
+    CastToU,
+    CastToChar,
+    CastToBool,
+
     HLT,
-    
+
     Nop,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum Address {
-    #[default]
-    ToDefine,
+    ToDefine(Intern<String>),
     Val(usize),
 }
 
@@ -63,7 +81,7 @@ impl From<&Address> for usize {
     #[inline(always)]
     fn from(value: &Address) -> Self {
         match value {
-            Address::ToDefine => panic!(),
+            Address::ToDefine(_i) => panic!(),
             Address::Val(addr) => *addr,
         }
     }

--- a/vm/src/instruction/mod.rs
+++ b/vm/src/instruction/mod.rs
@@ -65,6 +65,7 @@ pub enum Instruction {
     CastToU,
     CastToChar,
     CastToBool,
+    CastToPtr,
 
     HLT,
 

--- a/vm/src/instruction/mod.rs
+++ b/vm/src/instruction/mod.rs
@@ -33,6 +33,7 @@ pub enum Instruction {
     Jmp(Address),
     JmpNZ(Address),
     JmpZ(Address),
+    ExternCall(usize),
     Call(Address), //Should it uses the top of the stack value as adress if the Address is `ToDefine`? Or maybe adding another way?
     Ret,
 

--- a/vm/src/main.rs
+++ b/vm/src/main.rs
@@ -1,13 +1,6 @@
-use std::time::Duration;
-
 use vm::instruction::compiler::parser::Parser;
-use vm::instruction::{Address, Instruction::*};
 
-use vm::memory::object_map::Structure;
-use vm::memory::vm_data::VMData;
 use vm::runtime::VM;
-
-const TEST_AMOUNT: usize = 10;
 
 fn main() {
     // std::env::set_var("RUST_BACKTRACE", "1");

--- a/vm/src/main.rs
+++ b/vm/src/main.rs
@@ -23,27 +23,32 @@ fn main() {
         stack_machine.clean();
     }
     println!("tmp1: {:?}", tmp.div_f32(TEST_AMOUNT as f32));*/
-
-    if let Ok(content) = std::fs::read_to_string("./vm/src/example.txt") {
+    let tmp = std::time::Instant::now();
+    if let Ok(content) = std::fs::read_to_string("./vm/src/brainfuck.txt") {
         let mut lexer = vm::instruction::compiler::lexer::AtlasLexer::default();
-        lexer.set_path("src/example.txt");
+        lexer.set_path("src/brainfuck.txt");
         lexer.set_source(content);
         lexer.add_system(vm::instruction::compiler::lexer::identifier_system);
         lexer.add_system(vm::instruction::compiler::lexer::comment_system);
         let res = lexer.tokenize();
         match res {
             Ok(t) => {
-                println!("ok lexer");
+                println!("Ok Lexer: {:?}", tmp.elapsed());
+                let tmp = std::time::Instant::now();
                 //t.clone().into_iter().for_each(|ins| println!("{:?}, ", ins.kind()));
                 let parser = Parser::parse(t);
                 match parser {
                     Ok(code) => {
-                        println!("ok parser");
+                        println!("Ok Parser: {:?}", tmp.elapsed());
+                        let tmp = std::time::Instant::now();
                         //code.clone().into_iter().for_each(|ins| println!("{:?}", ins));
                         let mut vm = VM::new();
                         #[cfg(debug_assertions)]
+                        println!("{:?}", code.fn_name);
+                        #[cfg(debug_assertions)]
                         vm.set_fn_name(code.fn_name);
                         vm.execute(code.ins, code.constants);
+                        println!("Ok Excution: {:?}", tmp.elapsed())
                     }
                     Err(e) => {
                         panic!("{:?}", e);

--- a/vm/src/main.rs
+++ b/vm/src/main.rs
@@ -1,38 +1,19 @@
-#[allow(unused)]
-
 use std::time::Duration;
 
+use vm::instruction::compiler::parser::Parser;
 use vm::instruction::{Address, Instruction::*};
 
+use vm::memory::object_map::Structure;
+use vm::memory::vm_data::VMData;
 use vm::runtime::VM;
 
 const TEST_AMOUNT: usize = 10;
 
 fn main() {
-    //env::set_var("RUST_BACKTRACE", "1");
-    let mut tmp = Duration::new(0, 0);
+    // std::env::set_var("RUST_BACKTRACE", "1");
+    /*let mut tmp = Duration::new(0, 0);
     let mut stack_machine = VM::new();
-    let ins = vec![
-        PushI(35),
-        Call(Address::Val(4)),
-        Nop,
-        HLT,
-        Dup,
-        PushI(2),
-        Lt,
-        JumpIfFalse(Address::Val(9)),
-        Ret,
-        Dup,
-        PushI(1),
-        SubI,
-        Call(Address::Val(4)),
-        Swap,
-        PushI(2),
-        SubI,
-        Call(Address::Val(4)),
-        AddI,
-        Ret,
-    ];
+    let ins = vec![];
     for _ in 0..TEST_AMOUNT {
         use std::time;
         let ins = ins.clone();
@@ -41,21 +22,39 @@ fn main() {
         tmp += instant.elapsed();
         stack_machine.clean();
     }
-    println!("tmp1: {:?}", tmp.div_f32(TEST_AMOUNT as f32));
+    println!("tmp1: {:?}", tmp.div_f32(TEST_AMOUNT as f32));*/
 
-    /*if let Ok(content) = std::fs::read_to_string("./vm/src/example.txt") {
-        let mut lexer = AtlasLexer::default();
+    if let Ok(content) = std::fs::read_to_string("./vm/src/example.txt") {
+        let mut lexer = vm::instruction::compiler::lexer::AtlasLexer::default();
         lexer.set_path("src/example.txt");
         lexer.set_source(content);
-        lexer.add_system(identifier_system);
+        lexer.add_system(vm::instruction::compiler::lexer::identifier_system);
+        lexer.add_system(vm::instruction::compiler::lexer::comment_system);
         let res = lexer.tokenize();
         match res {
-            Ok(t) => t.into_iter().for_each(|tok| println!("{:?}", tok.kind())),
+            Ok(t) => {
+                println!("ok lexer");
+                //t.clone().into_iter().for_each(|ins| println!("{:?}, ", ins.kind()));
+                let parser = Parser::parse(t);
+                match parser {
+                    Ok(code) => {
+                        println!("ok parser");
+                        //code.clone().into_iter().for_each(|ins| println!("{:?}", ins));
+                        let mut vm = VM::new();
+                        #[cfg(debug_assertions)]
+                        vm.set_fn_name(code.fn_name);
+                        vm.execute(code.ins, code.constants);
+                    }
+                    Err(e) => {
+                        panic!("{:?}", e);
+                    }
+                };
+            }
             Err(_e) => {
                 println!("Error1");
             }
         }
     } else {
         println!("Error2")
-    }*/
+    }
 }

--- a/vm/src/memory/mod.rs
+++ b/vm/src/memory/mod.rs
@@ -1,3 +1,3 @@
-pub(crate) mod object_map;
-pub(crate) mod stack;
-pub(crate) mod vm_data;
+pub mod object_map;
+pub mod stack;
+pub mod vm_data;

--- a/vm/src/memory/object_map.rs
+++ b/vm/src/memory/object_map.rs
@@ -129,5 +129,5 @@ impl From<String> for Object {
 
 #[derive(Clone, Debug)]
 pub struct Structure {
-    fields: Vec<VMData>,
+    pub fields: Vec<VMData>,
 }

--- a/vm/src/memory/stack.rs
+++ b/vm/src/memory/stack.rs
@@ -1,4 +1,4 @@
-use std::fmt::{format, Display};
+use std::fmt::Display;
 
 use crate::memory::vm_data::VMData;
 
@@ -7,6 +7,11 @@ const STACK_SIZE: usize = 16 * 1024 / size_of::<VMData>();
 pub struct Stack {
     values: [VMData; STACK_SIZE],
     pub top: usize,
+}
+impl Default for Stack {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 // TODO: this implementation should be overhauled a bit cuz it's kinda clunky
@@ -19,7 +24,7 @@ impl Stack {
     }
 
     pub fn push(&mut self, val: VMData) {
-        if !(self.top >= STACK_SIZE) {
+        if self.top < STACK_SIZE {
             self.values[self.top] = val;
             self.top += 1;
         } else {

--- a/vm/src/memory/stack.rs
+++ b/vm/src/memory/stack.rs
@@ -54,7 +54,7 @@ impl Display for Stack {
             "Stack: {{ values: {}, top: {}}}",
             {
                 let mut s = "[".to_string();
-                for i in 0..self.top-1 {
+                for i in 0..self.top - 1 {
                     s.push_str(&format!("{:?}, ", self.values[i]))
                 }
                 s.push(']');

--- a/vm/src/memory/stack.rs
+++ b/vm/src/memory/stack.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::fmt::{format, Display};
 
 use crate::memory::vm_data::VMData;
 
@@ -54,9 +54,9 @@ impl Display for Stack {
             "Stack: {{ values: {}, top: {}}}",
             {
                 let mut s = "[".to_string();
-                self.values.into_iter().for_each(|v| {
-                    s.push_str(&format!("{}, ", &v.to_string()));
-                });
+                for i in 0..self.top-1 {
+                    s.push_str(&format!("{:?}, ", self.values[i]))
+                }
                 s.push(']');
                 s
             },

--- a/vm/src/memory/vm_data.rs
+++ b/vm/src/memory/vm_data.rs
@@ -9,6 +9,7 @@ pub union RawVMData {
     as_u64: u64,
     as_f64: f64,
     as_bool: bool,
+    as_char: char,
     as_object: ObjectIndex,
 }
 
@@ -34,6 +35,7 @@ impl VMData {
     pub const TAG_FLOAT: u64 = 9;
     pub const TAG_BOOL: u64 = 10;
     pub const TAG_STR: u64 = 11;
+    pub const TAG_CHAR: u64 = 12;
 
     pub fn new(tag: u64, data: RawVMData) -> Self {
         Self { tag, data }
@@ -62,6 +64,7 @@ impl VMData {
     def_new_vmdata_func!(new_u64, as_u64, u64, TAG_U64);
     def_new_vmdata_func!(new_f64, as_f64, f64, TAG_FLOAT);
     def_new_vmdata_func!(new_bool, as_bool, bool, TAG_BOOL);
+    def_new_vmdata_func!(new_char, as_char, char, TAG_CHAR);
 }
 
 impl PartialEq for VMData {
@@ -69,12 +72,12 @@ impl PartialEq for VMData {
         if self.tag != other.tag {
             return false;
         }
-
         match self.tag {
             Self::TAG_BOOL => self.as_bool() == other.as_bool(),
             Self::TAG_FLOAT => self.as_f64() == other.as_f64(),
             Self::TAG_I64 => self.as_i64() == other.as_i64(),
             Self::TAG_U64 => self.as_u64() == other.as_u64(),
+            Self::TAG_CHAR => self.as_char() == other.as_char(),
             Self::TAG_UNIT => true,
             _ if self.tag > 256 => self.as_object() == other.as_object(),
             _ => panic!("Illegal comparison"),
@@ -87,11 +90,11 @@ impl PartialOrd for VMData {
         if self.tag != other.tag {
             return None;
         }
-
         match self.tag {
             Self::TAG_FLOAT => self.as_f64().partial_cmp(&other.as_f64()),
             Self::TAG_U64 => self.as_u64().partial_cmp(&other.as_u64()),
             Self::TAG_I64 => self.as_i64().partial_cmp(&other.as_i64()),
+            Self::TAG_CHAR => self.as_char().partial_cmp(&other.as_char()),
             _ => panic!("Illegal comparison"),
         }
     }
@@ -108,6 +111,7 @@ impl Display for VMData {
                 Self::TAG_U64 => self.as_u64().to_string(),
                 Self::TAG_FLOAT => self.as_f64().to_string(),
                 Self::TAG_BOOL => self.as_bool().to_string(),
+                Self::TAG_CHAR => self.as_char().to_string(),
 
                 _ if self.is_object() => self.as_object().to_string(),
                 _ => "reserved".to_string(),
@@ -128,6 +132,7 @@ impl std::fmt::Debug for VMData {
                 Self::TAG_FLOAT => "f64",
                 Self::TAG_I64 => "i64",
                 Self::TAG_U64 => "u64",
+                Self::TAG_CHAR => "char",
                 _ if self.is_object() => "obj",
                 _ => "res",
             },
@@ -137,6 +142,7 @@ impl std::fmt::Debug for VMData {
                 Self::TAG_U64 => self.as_u64().to_string(),
                 Self::TAG_FLOAT => self.as_f64().to_string(),
                 Self::TAG_BOOL => self.as_bool().to_string(),
+                Self::TAG_CHAR => self.as_char().to_string(),
                 _ if self.is_object() => self.as_object().to_string(),
                 _ => "reserved".to_string(),
             }
@@ -165,6 +171,7 @@ impl VMData {
     enum_variant_function!(as_f64, is_f64, TAG_FLOAT, f64);
     enum_variant_function!(as_u64, is_u64, TAG_U64, u64);
     enum_variant_function!(as_bool, is_bool, TAG_BOOL, bool);
+    enum_variant_function!(as_char, is_char, TAG_CHAR, char);
     enum_variant_function!(as_unit, is_unit, TAG_UNIT, ());
 
     #[inline(always)]

--- a/vm/src/runtime/mod.rs
+++ b/vm/src/runtime/mod.rs
@@ -1,8 +1,12 @@
-use std::{thread, time::Duration};
+use std::{thread::{self, sleep}, time::Duration};
 
 use crate::{
     instruction::Instruction,
-    memory::{object_map::Memory, stack::Stack, vm_data::VMData},
+    memory::{
+        object_map::{Memory, Object, ObjectIndex, Structure},
+        stack::Stack,
+        vm_data::VMData,
+    },
 };
 
 pub struct VM {
@@ -10,6 +14,8 @@ pub struct VM {
     pub object_map: Memory,
     constants: Vec<VMData>,
     call_stack: Vec<usize>,
+    #[cfg(debug_assertions)]
+    fn_name: Vec<(String, usize)>,
     pc: usize,
 }
 
@@ -20,6 +26,8 @@ impl VM {
             object_map: Memory::new(16),
             constants: vec![],
             call_stack: vec![],
+            #[cfg(debug_assertions)]
+            fn_name: vec![],
             pc: usize::default(),
         }
     }
@@ -29,22 +37,30 @@ impl VM {
         self.call_stack = vec![];
         self.pc = usize::default();
     }
-    pub fn execute(&mut self, ins: Vec<Instruction>) {
+    #[cfg(debug_assertions)]
+    pub fn set_fn_name(&mut self, fn_name: Vec<(String, usize)>) -> &mut Self {
+        self.fn_name = fn_name;
+        self
+    }
+    pub fn execute(&mut self, ins: Vec<Instruction>, consts: Vec<VMData>) {
+        self.constants = consts;
         while self.pc < ins.len() {
             let ins = &ins[self.pc];
             #[cfg(debug_assertions)]
             println!("{:?}", ins);
+            //#[cfg(debug_assertions)]
+            //println!("Memory: [{:?}, {:?}, {:?}]", self.object_map.get(ObjectIndex::new(0)), self.object_map.get(ObjectIndex::new(1)), self.object_map.get(ObjectIndex::new(2)));
             match ins {
                 Instruction::HLT => break,
                 _ => {
                     self.execute_instruction(ins);
                 }
             }
-            #[cfg(debug_assertions)]
-            println!("{}", self.stack);
+            //#[cfg(debug_assertions)]
+            //println!("{}", self.stack);
 
-            #[cfg(debug_assertions)]
-            thread::sleep(Duration::from_millis(250));
+            //#[cfg(debug_assertions)]
+            //thread::sleep(Duration::from_millis(250));
         }
         self.clean();
     }
@@ -160,16 +176,16 @@ impl VM {
                 self.pc = address.into();
                 return;
             }
-            JumpIfTrue(address) => {
-                let val = self.stack.pop().expect("Stack Underflow").as_bool();
-                if val {
+            JmpNZ(address) => {
+                let val = self.stack.pop().expect("Stack Underflow").as_u64();
+                if val != 0 {
                     self.pc = address.into();
                     return;
                 }
             }
-            JumpIfFalse(address) => {
-                let val = self.stack.pop().expect("Stack Underflow").as_bool();
-                if !val {
+            JmpZ(address) => {
+                let val = self.stack.pop().expect("Stack Underflow").as_u64();
+                if val == 0 {
                     self.pc = address.into();
                     return;
                 }
@@ -177,26 +193,218 @@ impl VM {
             Call(address) => {
                 self.call_stack.push(self.pc + 1);
                 self.pc = address.into();
+                #[cfg(debug_assertions)]
+                {
+                    let name = (&self.fn_name).into_iter().find(|f| {
+                        f.1 == address.into() 
+                    });
+                    println!("{:?}", self.fn_name);
+                    match name {
+                        Some(n) => println!("call {}", n.0),
+                        None => panic!("Tf you calling?")
+                    }
+                }
                 return;
             }
             Ret => {
                 self.pc = self.call_stack.pop().expect("Call Stack Underflow");
+                //println!("return: {}", self.stack);
                 return;
             }
+            CastToI => {
+                let val = self.stack.pop().expect("Stack Underflow");
+                let res = match val.tag {
+                    VMData::TAG_CHAR => {
+                        val.as_char() as i64
+                    },
+                    VMData::TAG_I64 => {
+                        val.as_i64()
+                    }
+                    VMData::TAG_FLOAT => {
+                        val.as_f64() as i64
+                    }
+                    VMData::TAG_U64 => {
+                        val.as_u64() as i64
+                    }
+                    VMData::TAG_BOOL => {
+                        val.as_bool() as i64
+                    }
+                    _ => unimplemented!("cast_to_int isn't implement for tag: {}", val.tag)
+                };
+                self.stack.push(VMData::new_i64(res));
+            },
+            CastToF => {
+                let val = self.stack.pop().expect("Stack Underflow");
+                let res = match val.tag {
+                    VMData::TAG_CHAR => {
+                        val.as_char() as i64 as f64
+                    },
+                    VMData::TAG_I64 => {
+                        val.as_i64() as f64
+                    }
+                    VMData::TAG_FLOAT => {
+                        val.as_f64() as f64
+                    }
+                    VMData::TAG_U64 => {
+                        val.as_u64() as f64
+                    }
+                    VMData::TAG_BOOL => {
+                        val.as_bool() as i64 as f64
+                    }
+                    _ => unimplemented!("cast_to_float isn't implement for tag: {}", val.tag)
+                };
+                self.stack.push(VMData::new_f64(res));
+            },
+            CastToU => {
+                let val = self.stack.pop().expect("Stack Underflow");
+                let res = match val.tag {
+                    VMData::TAG_CHAR => {
+                        val.as_char() as u64
+                    },
+                    VMData::TAG_I64 => {
+                        val.as_i64() as u64
+                    }
+                    VMData::TAG_FLOAT => {
+                        val.as_f64() as u64
+                    }
+                    VMData::TAG_U64 => {
+                        val.as_u64() as u64
+                    }
+                    VMData::TAG_BOOL => {
+                        val.as_bool() as u64
+                    }
+                    _ => unimplemented!("cast_to_uint isn't implement for tag: {}", val.tag)
+                };
+                self.stack.push(VMData::new_u64(res));
+            },
+            CastToChar => {
+                let val = self.stack.pop().expect("Stack Underflow");
+                println!("[{:?}; {}]", val, self.pc);
+                let res = match val.tag {
+                    VMData::TAG_CHAR => {
+                        val.as_char() as char
+                    },
+                    VMData::TAG_I64 => {
+                        println!("cast {}", self.stack);
+                        val.as_i64() as u8 as char
+                    }
+                    VMData::TAG_FLOAT => {
+                        char::from_u32(val.as_f64() as u32).unwrap()
+                    }
+                    VMData::TAG_U64 => {
+                        char::from_u32(val.as_u64() as u32).unwrap()
+                    }
+                    VMData::TAG_BOOL => {
+                        val.as_bool() as u8 as char
+                    }
+                    _ => unimplemented!("cast_to_int isn't implement for tag: {} [{}]", val.tag, self.pc)
+                };
+                self.stack.push(VMData::new_char(res));
+            },
+            CastToBool => {
+                let val = self.stack.pop().expect("Stack Underflow");
+                let res = match val.tag {
+                    VMData::TAG_CHAR => {
+                        val.as_char() as i64
+                    },
+                    VMData::TAG_I64 => {
+                        val.as_i64()
+                    }
+                    VMData::TAG_FLOAT => {
+                        val.as_f64() as i64
+                    }
+                    VMData::TAG_U64 => {
+                        val.as_u64() as i64
+                    }
+                    VMData::TAG_BOOL => {
+                        val.as_bool() as i64
+                    }
+                    _ => unimplemented!("cast_to_int isn't implement for tag: {}", val.tag)
+                };
+                self.stack.push(VMData::new_i64(res));
+            },
             Read => {
                 let mut input = String::new();
                 std::io::stdin()
                     .read_line(&mut input)
                     .expect("Failed to read input");
                 let val = String::from(input.trim());
+                //println!("Read string: {}", val);
                 match self.object_map.put(val.into()) {
                     Ok(i) => {
                         self.stack.push(VMData::new_string(i));
                     }
                     Err(o) => {
-                        println!("Memory full, can't insert: [{:?}]", o);
+                        panic!("Memory full, can't insert: [{:?}]", o);
                     }
                 }
+            }
+            ReadI => {
+                let mut input = String::new();
+                std::io::stdin()
+                    .read_line(&mut input)
+                    .expect("Failed to read input");
+                let val = match String::from(input.trim()).parse::<i64>() {
+                    Ok(i) => i,
+                    Err(e) => {
+                        panic!("{}", e);
+                    }
+                };
+                self.stack.push(VMData::new_i64(val));
+            }
+            SetStruct(u) => {
+                let ptr = self.stack.pop().expect("Stack underflow").as_object();
+                let val = self.stack.pop().expect("Stack underflow");
+                self.object_map.get_mut(ptr).structure_mut().fields[*u] = val;
+            }
+            GetStruct(u) => {
+                let ptr = self.stack.pop().expect("Stack underflow").as_object();
+                let field = self.object_map.get(ptr).structure().fields[*u];
+                self.stack.push(field);
+            }
+            CreateStruct(u) => {
+                let s = Structure {
+                    fields: vec![VMData::new_unit(); *u],
+                };
+                match self.object_map.put(s.into()) {
+                    Ok(ptr) => {
+                        self.stack.push(VMData::new_object(257, ptr));
+                    }
+                    Err(o) => {
+                        panic!("Can't add :[{:?}] in the memory", o);
+                    }
+                }
+            }
+
+            CreateString => match self.object_map.put(String::new().into()) {
+                Ok(ptr) => {
+                    self.stack.push(VMData::new_string(ptr));
+                }
+                Err(o) => {
+                    panic!("Can't add :[{:?}] in the memory", o);
+                }
+            },
+            StrLen => {
+                let ptr = self.stack.pop().expect("Stack underflow").as_object();
+                let len = self.object_map.get(ptr).string().len();
+                //println!("ptr: {:?}, len: {}", ptr, len);
+                self.stack.push(VMData::new_i64(len as i64));
+            }
+            WriteCharToString => {
+                let ptr = self.stack.pop().expect("Stack underflow").as_object();
+                let ch = self.stack.pop().expect("Stack underflow").as_char();
+                self.object_map.get_mut(ptr).string_mut().push(ch);
+            }
+            ReadCharFromString => {
+                let ptr = self.stack.pop().expect("Stack underflow").as_object();
+                let i = self.stack.pop().expect("Stack underflow").as_u64();
+                let ch = match self.object_map.get(ptr).string().chars().nth(i as usize) {
+                    Some(c) => c,
+                    None => {
+                        panic!("Index out of bound for string: {}[{}]", ptr, i);
+                    }
+                };
+                self.stack.push(VMData::new_char(ch));
             }
             Instruction::Eq => {
                 let b = self.stack.pop().expect("Stack underflow");
@@ -241,6 +449,11 @@ impl VM {
             Instruction::Not => {
                 let value = self.stack.pop().expect("Stack underflow").as_bool();
                 self.stack.push(VMData::new_bool(!value));
+            }
+            PrintChar => {
+                let value = self.stack.pop().expect("Stack Underflow").as_char();
+                println!("{}", value);
+                
             }
             Nop => {}
             _ => unimplemented!(),

--- a/vm/src/runtime/mod.rs
+++ b/vm/src/runtime/mod.rs
@@ -1,12 +1,7 @@
-use std::{
-    thread::{self, sleep},
-    time::Duration,
-};
-
 use crate::{
     instruction::Instruction,
     memory::{
-        object_map::{Memory, Object, ObjectIndex, Structure},
+        object_map::{Memory, ObjectIndex, Structure},
         stack::Stack,
         vm_data::VMData,
     },
@@ -22,6 +17,11 @@ pub struct VM {
     pc: usize,
 }
 
+impl Default for VM {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 impl VM {
     pub fn new() -> Self {
         Self {
@@ -198,7 +198,7 @@ impl VM {
                 self.pc = address.into();
                 #[cfg(debug_assertions)]
                 {
-                    let name = (&self.fn_name).into_iter().find(|f| f.1 == address.into());
+                    let name = self.fn_name.iter().find(|f| f.1 == address.into());
                     match name {
                         Some(n) => println!("call {}", n.0),
                         None => panic!("Tf you calling?, {} in {:?}", self.pc, self.fn_name),
@@ -245,7 +245,7 @@ impl VM {
                 let res = match val.tag {
                     VMData::TAG_CHAR => val.as_char() as i64 as f64,
                     VMData::TAG_I64 => val.as_i64() as f64,
-                    VMData::TAG_FLOAT => val.as_f64() as f64,
+                    VMData::TAG_FLOAT => val.as_f64(),
                     VMData::TAG_U64 => val.as_u64() as f64,
                     VMData::TAG_BOOL => val.as_bool() as i64 as f64,
                     _ => unimplemented!("cast_to_float isn't implement for tag: {}", val.tag),
@@ -258,7 +258,7 @@ impl VM {
                     VMData::TAG_CHAR => val.as_char() as u64,
                     VMData::TAG_I64 => val.as_i64() as u64,
                     VMData::TAG_FLOAT => val.as_f64() as u64,
-                    VMData::TAG_U64 => val.as_u64() as u64,
+                    VMData::TAG_U64 => val.as_u64(),
                     VMData::TAG_BOOL => val.as_bool() as u64,
                     _ => unimplemented!("cast_to_uint isn't implement for tag: {}", val.tag),
                 };
@@ -267,7 +267,7 @@ impl VM {
             CastToChar => {
                 let val = self.stack.pop().expect("Stack Underflow");
                 let res = match val.tag {
-                    VMData::TAG_CHAR => val.as_char() as char,
+                    VMData::TAG_CHAR => val.as_char(),
                     VMData::TAG_I64 => val.as_i64() as u8 as char,
                     VMData::TAG_FLOAT => char::from_u32(val.as_f64() as u32).unwrap(),
                     VMData::TAG_U64 => char::from_u32(val.as_u64() as u32).unwrap(),

--- a/vm/src/runtime/vm_state.rs
+++ b/vm/src/runtime/vm_state.rs
@@ -1,0 +1,17 @@
+use crate::memory::{object_map::Memory, stack::Stack, vm_data::VMData};
+
+pub struct VMState<'state> {
+    pub stack: &'state mut Stack,
+    pub object_map: &'state mut Memory,
+    pub consts: &'state [VMData]
+}
+
+impl<'state> VMState<'state> {
+    pub fn new(stack: &'state mut Stack, object_map: &'state mut Memory, consts: &'state [VMData]) -> Self {
+        Self {
+            stack,
+            object_map,
+            consts
+        }
+    }
+}


### PR DESCRIPTION
Where to start....

- Cleaned up the VM using `cargo clippy`
- Introduced several new instructions:
  - External function calls: `extern_call`.
  - Constants usage: `load_const`.
  - Casting instructions: `cast_to_int`, `cast_to_float`, `cast_to_uint`, `cast_to_char`, `cast_to_bool`, `cast_to_ptr`.
  - Struct operations: `create_struct`, `get_struct`, `set_struct`.
  - String operations: `create_string`, `read_string`, `write_char`, `str_len`.
- Added an assembler to convert text to bytecode using our custom lexer generator library `atlas-core` (still needs more testing and feature enhancements).
- Introduced a way to define constants in the bytecode: `@type name value`
- Added `VMState`, which is passed to external function calls, allowing them to access and modify the VM for more complex operations.
- Added examples: fib.txt, extern_call.txt & brainfuck.txt (brainfuck is still unstable and all the operations don't work e.g. `[`, `]` & `,`)